### PR TITLE
Update link to code of conduct in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This project is subject to the MIT License. A copy of this license is in [Licens
 
 ## Code of Conduct
 
-This project has adopted the [Contributor Covenant](https://contributor-covenant.org/) code of conduct to clarify expected behavior in our community. You can read it at [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
+This project has adopted the [Contributor Covenant](https://contributor-covenant.org/) code of conduct to clarify expected behavior in our community. You can read it at [the .NET Foundation website](https://dotnetfoundation.org/about/policies/code-of-conduct).
 
 ## Get In Touch
 


### PR DESCRIPTION
CODE_OF_CONDUCT just contains a link that redirects to the .NET Foundation website. With this link update, readers have to click only once rather than twice. Besides, the README says, "You can read [the code of conduct] at [the link]," which seems incorrect if the given link does not in fact contain the text of the code of conduct.